### PR TITLE
Install virtualenv along with poetry

### DIFF
--- a/{{cookiecutter.project_slug}}/Dockerfile
+++ b/{{cookiecutter.project_slug}}/Dockerfile
@@ -21,7 +21,7 @@ RUN set -ex; \
   apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
   rm -rf /var/lib/apt/lists/*
 
-RUN pip install -U poetry
+RUN pip install -U poetry virtualenv
 
 # Copy, then install requirements before copying rest for a requirements cache layer.
 COPY pyproject.toml poetry.lock /tmp/


### PR DESCRIPTION
# Issue

When building the Docker image it exited with;
```
#0 1.839 No module named 'virtualenv.seed'; 'virtualenv' is not a package
```

# Cause
`virtualenv` no longer included with `poetry`

# Fix
Install `virtualenv` along with `poetry`